### PR TITLE
Add optional flag for DOCKER_MACHINE_IP

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -10,7 +10,7 @@ play {
 env {
   db {
     host = "127.0.0.1"
-    host = ${DOCKER_MACHINE_IP}
+    host = ${?DOCKER_MACHINE_IP}
   }
 }
 


### PR DESCRIPTION
Currently tests fail if DOCKER_MACHINE_IP is not specified